### PR TITLE
GIT-58 Improve configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,34 @@
 # gitguesser
+
+## CONFIGURATION
+
+Environment variables are used to manage application settings. 
+Alternatively, you can store them in configuration files located in the 
+project's root directory. The default configuration file is `.env`. During 
+testing with `pytest`, the configuration is read from `.env.test`.
+
+The following variables are required:
+- `POSTGRES_USER`
+- `POSTGRES_PASSWORD`
+- `POSTGRES_SERVER`
+- `POSTGRES_PORT`
+- `POSTGRES_DB`
+
+The following variables are optional:
+- `GITHUB_USERNAME`
+- `GITHUB_TOKEN`
+
+However, it is strongly recommended to provide them, as they can increase the GitHub API rate limit.
+
+Here is an example of a valid configuration file:
+<details>
+<summary>Click to expand</summary>
+
+```bash
+POSTGRES_USER=gitguesser
+POSTGRES_PASSWORD=gitguesser
+POSTGRES_SERVER=db
+POSTGRES_PORT=5432
+POSTGRES_DB=gitguesser_db
+```
+</details>

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -1,3 +1,5 @@
+import sys
+
 from pydantic import BaseSettings
 
 
@@ -8,18 +10,17 @@ class Settings(BaseSettings):
     initialized using the values from both environment variables and
     the content of .env file.
     """
-
-    # We don't provide this values currently and our app won't start without them
-    # postgres_user: str
-    # postgres_password: str
-    # postgres_server: str
-    # postgres_port: int
-    # postgres_db: str
-    database_url: str
+    postgres_user: str
+    postgres_password: str
+    postgres_server: str
+    postgres_port: int
+    postgres_db: str
+    github_username: str | None
+    github_token: str | None
 
     class Config:
         case_sensitive = False
-        env_file = ".env"
+        env_file = ".env" if "pytest" not in sys.modules else ".env.test"
         env_file_encoding = "utf-8"
 
 

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -1,11 +1,14 @@
 from config import settings
 from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
-from sqlalchemy.ext.declarative import declarative_base
-from sqlalchemy.orm import sessionmaker
+from sqlalchemy.orm import sessionmaker, declarative_base
 
 engine = create_async_engine(
-    settings.database_url, echo=True
-)  # Maybe change echo to False in the future.
+    "postgresql+asyncpg://"
+    f"{settings.postgres_user}:{settings.postgres_password}@"
+    f"{settings.postgres_server}:{settings.postgres_port}/"
+    f"{settings.postgres_db}", 
+    echo=True,
+)
 Base = declarative_base()
 async_session = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
 

--- a/backend/app/services/repository_service.py
+++ b/backend/app/services/repository_service.py
@@ -31,7 +31,10 @@ async def update_repo(*, db: AsyncSession, owner: str, name: str, branch: str) -
     endpoint = (
         f"https://api.github.com/repos/{owner}/{name}/git/trees/{branch}?recursive=true"
     )
-    async with httpx.AsyncClient() as client:
+    auth = None
+    if settings.github_username and settings.github_token:
+        auth = (settings.github_username, settings.github_token)
+    async with httpx.AsyncClient(auth=auth) as client:
         if repo is None:
             response = await client.get(endpoint)
         else:

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,11 +1,8 @@
 services:
   db:
     image: postgres:15.2
+    env_file: .env
     restart: always
-    environment:
-      POSTGRES_USER: gitguesser
-      POSTGRES_PASSWORD: gitguesser
-      POSTGRES_DB: gitguesser_db
     expose:
       - 5432
     volumes:
@@ -13,14 +10,13 @@ services:
 
   backend:
     build: ./backend
-    working_dir: /backend/backend/app # Fixes not loading local modules.
-    command: bash -c 'while !</dev/tcp/db/5432; do sleep 1; done; uvicorn main:app --host 0.0.0.0'
+    working_dir: /backend/backend
+    env_file: .env
+    command: bash -c 'while !</dev/tcp/db/5432; do sleep 1; done; uvicorn app.main:app --host 0.0.0.0'
     volumes:
       - .:/backend
     ports:
       - 8000:8000
-    environment:
-      - DATABASE_URL=postgresql+asyncpg://gitguesser:gitguesser@db:5432/gitguesser_db
     depends_on:
       - db
 

--- a/compose.yaml
+++ b/compose.yaml
@@ -10,7 +10,7 @@ services:
 
   backend:
     build: ./backend
-    working_dir: /backend/backend
+    working_dir: /backend/backend/app # Fixes not loading local modules.
     env_file: .env
     command: bash -c 'while !</dev/tcp/db/5432; do sleep 1; done; uvicorn app.main:app --host 0.0.0.0'
     volumes:


### PR DESCRIPTION
This makes switching database (for example while testing) easier. Additionally, it allows to set GitHub API credentials to get a higher rate limit.